### PR TITLE
Add seed for numpy

### DIFF
--- a/hakkun_nodes.py
+++ b/hakkun_nodes.py
@@ -306,6 +306,8 @@ class PromptParser:
 
     def parse_prompt(self, prompt, tags_file, seed, extra1=None, extra2=None, tags=None):
         random.seed(seed)
+        np_seed = seed % 2**32
+        np.random.seed(np_seed)
         if isOk(tags_file):
             tags = load_text(tags_file)
 


### PR DESCRIPTION
Even with same seed, prompt's output changed because of `np.random.choice`.
Fix it by adding a `np.random.seed` with the current seed (formated for numpy), on top of `parse_prompt` method.